### PR TITLE
handle mpv's normalized stream-open-filename for magnet and hash

### DIFF
--- a/src/webtorrent.ts
+++ b/src/webtorrent.ts
@@ -111,14 +111,29 @@ function onLoadHook() {
   const url = mp.get_property('stream-open-filename', '');
 
   try {
-    if (/^magnet:/i.test(url)) {
-      runHook(url);
+    let cleanUrl = url;
+    const magnetIndex = url.indexOf('magnet:');
+    if (magnetIndex > 0) {
+      cleanUrl = url.substring(magnetIndex);
+    }
+
+    if (/^magnet:/i.test(cleanUrl)) {
+      runHook(cleanUrl);
     } else if (/\.torrent$/i.test(url)) {
       runHook(url);
-    } else if (/^[0-9A-F]{40}$/i.test(url)) {
-      runHook(url);
-    } else if (/^[0-9A-Z]{32}$/i.test(url)) {
-      runHook(url);
+    } else {
+      const basename = url.split('/').pop() || '';
+
+      if (/^[0-9A-F]{40}$/i.test(basename)) {
+        // check if it is a file to avoid matching actual files
+        if (!mp.utils.file_info(url)) {
+          runHook(basename);
+        }
+      } else if (/^[0-9A-Z]{32}$/i.test(basename)) {
+        if (!mp.utils.file_info(url)) {
+          runHook(basename);
+        }
+      }
     }
   } catch (_e) {
     const e = _e as Error;


### PR DESCRIPTION
mpv 0.41.0 normalizes `stream-open-filename` by prepending cwd (https://github.com/mpv-player/mpv/commit/b47fd2842a295fca9d7681a7a85a8371faad0c47).
This broke detection of magnet links and info-hashes.

This patch strips the leading path before checking for magnet links and info-hashes, fixing the issue.